### PR TITLE
Add test coverage

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,5 +4,10 @@
       "es2015": { "modules": false }
     }]
   ],
+  "env": {
+    "test": {
+      "presets": ["env", "stage-2"],
+    }
+  },
   "comments": false
 }

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ node_modules/
 npm-debug.log
 yarn-error.log
 demo/dist
+test/unit/coverage
 *.map

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ $ = `{enter: {opacity: [1, 0]}, leave: {opacity: [0, 1]}}`
 
 ```javascript
   this.$notify({
-    // (optional) 
+    // (optional)
     // Name of the notification holder
     group: 'foo',
 
@@ -72,7 +72,7 @@ $ = `{enter: {opacity: [1, 0]}, leave: {opacity: [0, 1]}}`
     // Class that will be assigned to the notification
     type: 'warning',
 
-    // (optional) 
+    // (optional)
     // Title (will be wrapped in div.notification-title)
     title: 'This is title',
 
@@ -225,7 +225,7 @@ Example:
 
 Plugin can use use `Velocity` library to make js-powered animations. To start using it you will have to manually install `velocity-animate` & supply the librarty to `vue-notification` plugin (reason for doing that is to reduce the size of this plugin).
 
-In your `main.js`: 
+In your `main.js`:
 
 ```javascript
 import Vue           from 'vue'
@@ -241,7 +241,7 @@ In the template you will have to set `animation-type="velocity"`.
 <notifications animation-type="velocity"/>
 ```
 
-The animation configuration consists of 2 objects/functions: `enter` and `leave`. 
+The animation configuration consists of 2 objects/functions: `enter` and `leave`.
 
 Example:
 
@@ -307,4 +307,10 @@ npm run build
 cd demo
 npm install
 npm run dev
+
+# Run tests
+npm run test
+
+# Watch unit tests
+npm run unit:watch
 ```

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "author": "euvl <yev.vlasenko@gmail.com>",
   "private": false,
   "scripts": {
-    "build": "cross-env NODE_ENV=production webpack --progress --hide-modules"
+    "build": "cross-env NODE_ENV=production webpack --progress --hide-modules",
+    "unit": "cross-env BABEL_ENV=test karma start test/unit/setup/karma.conf.js --single-run",
+    "unit:watch": "cross-env BABEL_ENV=test karma start test/unit/setup/karma.conf.js --watch",
+    "test": "npm run unit"
   },
   "main": "dist/index.js",
   "repository": {
@@ -27,18 +30,34 @@
     "notification"
   ],
   "devDependencies": {
+    "avoriaz": "^3.2.0",
     "babel-core": "^6.0.0",
     "babel-loader": "^6.0.0",
+    "babel-preset-env": "^1.6.0",
     "babel-preset-latest": "^6.0.0",
+    "babel-preset-stage-2": "^6.24.1",
+    "chai": "^4.1.1",
     "cross-env": "^3.0.0",
     "css-loader": "^0.25.0",
     "file-loader": "^0.9.0",
+    "karma": "^1.7.0",
+    "karma-coverage": "^1.1.1",
+    "karma-mocha": "^1.3.0",
+    "karma-phantomjs-launcher": "^1.0.4",
+    "karma-phantomjs-shim": "^1.4.0",
+    "karma-sinon-chai": "^1.3.1",
+    "karma-sourcemap-loader": "^0.3.7",
+    "karma-spec-reporter": "0.0.31",
+    "karma-webpack": "^2.0.4",
+    "mocha": "^3.5.0",
     "node-sass": "^4.5.0",
     "sass-loader": "^5.0.1",
+    "sinon": "^3.2.0",
+    "sinon-chai": "^2.12.0",
     "vue": "^2.0.0",
     "vue-loader": "^11.1.4",
     "vue-template-compiler": "^2.0.0",
-    "webpack": "^2.2.0",
-    "webpack-dev-server": "^2.2.0"
+    "webpack": "^2.7.0",
+    "webpack-dev-server": "^2.7.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,12 @@ var Notify = {
     this.installed = true
     this.params = params
 
+    const { velocity } = params
+
+    if (velocity) {
+      Notifications.configure({ velocity })
+    }
+
     Vue.component('notifications', Notifications)
     Vue.prototype.$notify = (params) => {
       if (typeof params === 'string') {

--- a/test/unit/.eslintrc
+++ b/test/unit/.eslintrc
@@ -1,0 +1,10 @@
+{
+  "parser": "babel-eslint",
+  "env": {
+    "mocha": true
+  },
+  "globals": {
+    "expect": true,
+    "sinon": true
+  }
+}

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -1,0 +1,13 @@
+import Vue from 'vue'
+
+Vue.config.productionTip = false
+
+// require all test files (files that ends with .spec.js)
+const testsContext = require.context('./specs', true, /\.spec$/)
+testsContext.keys().forEach(testsContext)
+
+// require all src files except main.js for coverage.
+// you can also change this to match only the subset of files that
+// you want coverage for.
+const srcContext = require.context('../../src', true, /^\.\/(?!main(\.js)?$)/)
+srcContext.keys().forEach(srcContext)

--- a/test/unit/setup/.mocha-webpack-setup.js
+++ b/test/unit/setup/.mocha-webpack-setup.js
@@ -1,0 +1,30 @@
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const jsdom = require('jsdom').jsdom;
+
+global.expect = chai.expect;
+global.sinon = sinon;
+
+chai.use(sinonChai);
+
+// Set up JS DOM
+const exposedProperties = ['window', 'navigator', 'document'];
+
+global.document = jsdom(
+  '<html><head><style></style></head><body></body></html>',
+);
+global.window = document.defaultView;
+
+Object.keys(document.defaultView).forEach(property => {
+  if (typeof global[property] === 'undefined') {
+    exposedProperties.push(property);
+    global[property] = document.defaultView[property];
+  }
+});
+
+global.navigator = {
+  userAgent: 'node.js',
+};
+
+documentRef = document;

--- a/test/unit/setup/karma.conf.js
+++ b/test/unit/setup/karma.conf.js
@@ -1,0 +1,24 @@
+const webpackConfig = require('./webpack.config.js');
+
+const travis = process.env.TRAVIS;
+
+module.exports = function karmaConfig(config) {
+  config.set({
+    browsers: ['PhantomJS'],
+    frameworks: ['mocha', 'sinon-chai'],
+    reporters: ['spec', 'coverage'],
+    files: ['../specs/**/*.+(vue|js)'],
+    preprocessors: {
+      '../specs/**/*.+(vue|js)': ['webpack', 'sourcemap'],
+    },
+    webpack: webpackConfig,
+    webpackMiddleware: {
+      noInfo: true,
+    },
+    coverageReporter: {
+      dir: '../coverage',
+      reporters: [{ type: 'lcov', subdir: '.' }],
+    },
+    browserNoActivityTimeout: 0,
+  });
+};

--- a/test/unit/setup/webpack.config.js
+++ b/test/unit/setup/webpack.config.js
@@ -1,0 +1,21 @@
+const path = require('path');
+
+const projectRoot = path.resolve(__dirname, '../../../');
+
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.vue$/,
+        loader: 'vue-loader',
+        exclude: /node_modules/,
+      },
+      {
+        test: /\.js$/,
+        loader: 'babel-loader',
+        include: [projectRoot],
+        exclude: /node_modules/,
+      },
+    ],
+  },
+};

--- a/test/unit/specs/Notifications.spec.js
+++ b/test/unit/specs/Notifications.spec.js
@@ -1,0 +1,520 @@
+import { mount } from 'avoriaz';
+import Notifications from '../../../src/Notifications.vue';
+import CssGroup from '../../../src/CssGroup.vue';
+import VelocityGroup from '../../../src/VelocityGroup.vue';
+
+describe('Notifications', () => {
+  describe('defaults', () => {
+    it('has correct default props', () => {
+      const wrapper = mount(Notifications);
+
+      expect(wrapper.vm.$props.width).to.eq(300);
+      expect(wrapper.vm.$props.reverse).to.eq(false);
+      expect(wrapper.vm.$props.position).to.deep.eq(['top', 'right']);
+      expect(wrapper.vm.$props.classes).to.eq('vue-notification');
+      expect(wrapper.vm.$props.animationType).to.eq('css');
+      expect(wrapper.vm.$props.animation.enter).to.exist;
+      expect(wrapper.vm.$props.animation.leave).to.exist;
+      expect(wrapper.vm.$props.speed).to.eq(300);
+      expect(wrapper.vm.$props.duration).to.eq(3000);
+      expect(wrapper.vm.$props.delay).to.eq(0);
+    });
+
+    it('list is empty', () => {
+      const wrapper = mount(Notifications);
+
+      expect(wrapper.data().list).to.deep.eq([]);
+    });
+  });
+
+  describe('methods', ()=> {
+    describe('addItem', () => {
+      describe('when no group', () => {
+        it('adds item to list', () => {
+          const wrapper = mount(Notifications);
+
+          const event = {
+            title: 'Title',
+            text: 'Text',
+            type: 'success',
+          };
+
+          const result = wrapper.vm.addItem(event);
+
+          expect(wrapper.data().list.length).to.eq(1);
+          expect(wrapper.data().list[0].id).to.exist;
+          expect(wrapper.data().list[0].title).to.eq('Title');
+          expect(wrapper.data().list[0].text).to.eq('Text');
+          expect(wrapper.data().list[0].type).to.eq('success');
+          expect(wrapper.data().list[0].state).to.eq(0);
+          expect(wrapper.data().list[0].speed).to.eq(300);
+          expect(wrapper.data().list[0].length).to.eq(3600);
+          expect(wrapper.data().list[0].timer).to.exist;
+        });
+      });
+
+      describe('when a group is defined and matches event group name', () => {
+        it('adds item to list', () => {
+          const propsData = {
+            group: 'Group',
+          };
+
+          const wrapper = mount(Notifications, { propsData });
+
+          const event = {
+            group: 'Group',
+            title: 'Title',
+            text: 'Text',
+            type: 'success',
+          };
+
+          const result = wrapper.vm.addItem(event);
+
+          expect(wrapper.data().list.length).to.eq(1);
+          expect(wrapper.data().list[0].id).to.exist;
+          expect(wrapper.data().list[0].title).to.eq('Title');
+          expect(wrapper.data().list[0].text).to.eq('Text');
+          expect(wrapper.data().list[0].type).to.eq('success');
+          expect(wrapper.data().list[0].state).to.eq(0);
+          expect(wrapper.data().list[0].speed).to.eq(300);
+          expect(wrapper.data().list[0].length).to.eq(3600);
+          expect(wrapper.data().list[0].timer).to.exist;
+        });
+      });
+
+      describe('when a group is defined and does not match event group name', () => {
+        it('does not add item to list', () => {
+          const propsData = {
+            group: 'Does Not Match',
+          };
+
+          const wrapper = mount(Notifications, { propsData });
+
+          const event = {
+            group: 'Group',
+            title: 'Title',
+            text: 'Text',
+            type: 'success',
+          };
+
+          const result = wrapper.vm.addItem(event);
+
+          expect(wrapper.data().list.length).to.eq(0);
+        });
+      });
+
+      describe('item property overrides', () => {
+        it('item length calculated from duration and speed props', () => {
+          const duration = 50;
+          const speed = 25;
+          const expectedLength = duration + 2 * speed;
+
+          const propsData = {
+            duration,
+            speed,
+          };
+
+          const wrapper = mount(Notifications, { propsData });
+
+          const event = {
+            group: 'Group',
+            title: 'Title',
+            text: 'Text',
+            type: 'success',
+          };
+
+          const result = wrapper.vm.addItem(event);
+
+          expect(wrapper.data().list.length).to.eq(1);
+          expect(wrapper.data().list[0].speed).to.eq(speed);
+          expect(wrapper.data().list[0].length).to.eq(expectedLength);
+        });
+      });
+
+      describe('order of inserted items', () => {
+        it('by default inserts items in reverse order', () => {
+          const wrapper = mount(Notifications);
+
+          const event1 = {
+            title: 'First',
+          };
+
+          const event2 = {
+            title: 'Second',
+          };
+
+          wrapper.vm.addItem(event1);
+          wrapper.vm.addItem(event2);
+
+          expect(wrapper.data().list.length).to.eq(2);
+          expect(wrapper.data().list[0].title).to.eq('Second');
+          expect(wrapper.data().list[1].title).to.eq('First');
+        });
+
+        it('when position is top and reverse is false, inserts in reverse order', () => {
+          const propsData = {
+            position: 'top right',
+            reverse: false,
+          };
+
+          const wrapper = mount(Notifications, { propsData });
+
+          const event1 = {
+            title: 'First',
+          };
+
+          const event2 = {
+            title: 'Second',
+          };
+
+          wrapper.vm.addItem(event1);
+          wrapper.vm.addItem(event2);
+
+          expect(wrapper.data().list.length).to.eq(2);
+          expect(wrapper.data().list[0].title).to.eq('Second');
+          expect(wrapper.data().list[1].title).to.eq('First');
+        });
+
+        it('when position is top and reverse is true, inserts in sequential order', () => {
+          const propsData = {
+            position: 'top right',
+            reverse: true,
+          };
+
+          const wrapper = mount(Notifications, { propsData });
+
+          const event1 = {
+            title: 'First',
+          };
+
+          const event2 = {
+            title: 'Second',
+          };
+
+          wrapper.vm.addItem(event1);
+          wrapper.vm.addItem(event2);
+
+          expect(wrapper.data().list.length).to.eq(2);
+          expect(wrapper.data().list[0].title).to.eq('First');
+          expect(wrapper.data().list[1].title).to.eq('Second');
+        });
+
+        it('when position is bottom and reverse is false, inserts in sequential order', () => {
+          const propsData = {
+            position: 'bottom right',
+            reverse: false,
+          };
+
+          const wrapper = mount(Notifications, { propsData });
+
+          const event1 = {
+            title: 'First',
+          };
+
+          const event2 = {
+            title: 'Second',
+          };
+
+          wrapper.vm.addItem(event1);
+          wrapper.vm.addItem(event2);
+
+          expect(wrapper.data().list.length).to.eq(2);
+          expect(wrapper.data().list[0].title).to.eq('First');
+          expect(wrapper.data().list[1].title).to.eq('Second');
+        });
+
+        it('when position is bottom and reverse is true, inserts in reverse order', () => {
+          const propsData = {
+            position: 'bottom right',
+            reverse: true,
+          };
+
+          const wrapper = mount(Notifications, { propsData });
+
+          const event1 = {
+            title: 'First',
+          };
+
+          const event2 = {
+            title: 'Second',
+          };
+
+          wrapper.vm.addItem(event1);
+          wrapper.vm.addItem(event2);
+
+          expect(wrapper.data().list.length).to.eq(2);
+          expect(wrapper.data().list[0].title).to.eq('Second');
+          expect(wrapper.data().list[1].title).to.eq('First');
+        });
+      });
+
+      describe('auto-destroy of items', () => {
+        it('item is destroyed after certain duration', () => {
+          const duration = 50;
+          const speed = 25;
+          const expectedLength = duration + 2 * speed;
+
+          const propsData = {
+            duration,
+            speed,
+          };
+
+          const clock = sinon.useFakeTimers();
+
+          const wrapper = mount(Notifications, { propsData });
+
+          const event = {
+            group: 'Group',
+            title: 'Title',
+            text: 'Text',
+            type: 'success',
+          };
+
+          const result = wrapper.vm.addItem(event);
+
+          expect(wrapper.data().list.length).to.eq(1);
+
+          clock.tick(expectedLength);
+
+          expect(wrapper.data().list.length).to.eq(0);
+
+          clock.restore();
+        });
+      });
+    });
+  });
+
+  describe('rendering', () => {
+    describe('notification wrapper', () => {
+      it('adds notification item with correct title and text', (done) => {
+        const wrapper = mount(Notifications);
+
+        const event = {
+          title: 'Title',
+          text: 'Text',
+          type: 'success',
+        };
+
+        wrapper.vm.addItem(event);
+
+        wrapper.vm.$nextTick(() => {
+          const notifications = wrapper.find('.notification-wrapper');
+
+          expect(notifications.length).to.eq(1);
+
+          const title = wrapper.first('.notification-title').text();
+          expect(title).to.eq('Title');
+
+          const text = wrapper.first('.notification-content').text();
+          expect(text).to.eq('Text');
+
+          done();
+        });
+      });
+
+      it('adds notification with correct inline styling', (done) => {
+        const wrapper = mount(Notifications);
+
+        const event = {
+          title: 'Title',
+          text: 'Text',
+          type: 'success',
+        };
+
+        wrapper.vm.addItem(event);
+
+        wrapper.vm.$nextTick(() => {
+          const notification = wrapper.first('.notification-wrapper');
+
+          expect(notification).to.exist;
+          expect(notification.element.style.transition).to.eq('all 300ms');
+
+          done();
+        });
+      });
+
+      it('adds the event type as css class body', (done) => {
+        const wrapper = mount(Notifications);
+
+        const event = {
+          title: 'Title',
+          text: 'Text',
+          type: 'success',
+        };
+
+        wrapper.vm.addItem(event);
+
+        wrapper.vm.$nextTick(() => {
+          const notification = wrapper.first('.notification-wrapper > div');
+
+          expect(notification).to.exist;
+          expect(notification.element.className).includes('notification')
+          expect(notification.element.className).includes('vue-notification')
+          expect(notification.element.className).includes('success')
+
+          done();
+        });
+      });
+
+      it('has correct default body classes', (done) => {
+        const wrapper = mount(Notifications);
+
+        const event = {
+          title: 'Title',
+          text: 'Text',
+          type: 'success',
+        };
+
+        wrapper.vm.addItem(event);
+
+        wrapper.vm.$nextTick(() => {
+          const notification = wrapper.first('.notification-wrapper > div');
+
+          expect(notification).to.exist;
+          expect(notification.element.className).includes('vue-notification')
+
+          done();
+        });
+      });
+
+      it('body classes can be customized via prop', (done) => {
+        const propsData = {
+          classes: 'pizza taco-sushi'
+        };
+
+        const wrapper = mount(Notifications, { propsData });
+
+        const event = {
+          title: 'Title',
+          text: 'Text',
+          type: 'success',
+        };
+
+        wrapper.vm.addItem(event);
+
+        wrapper.vm.$nextTick(() => {
+          const notification = wrapper.first('.notification-wrapper > div');
+
+          expect(notification).to.exist;
+          expect(notification.element.className).includes('pizza');
+          expect(notification.element.className).includes('taco-sushi');
+
+          done();
+        });
+      });
+    });
+
+    describe('transition wrapper', () => {
+      it('default is css transition', () => {
+        const wrapper = mount(Notifications);
+
+        const event = {
+          title: 'Title',
+          text: 'Text',
+          type: 'success',
+        };
+
+        expect(wrapper.find(CssGroup).length).to.eq(1);
+        expect(wrapper.find(VelocityGroup).length).to.eq(0);
+      });
+
+      it('uses using velocity transition when enabled via prop', () => {
+        const propsData = {
+          animationType: 'velocity',
+        };
+
+        const wrapper = mount(Notifications, { propsData });
+
+        const event = {
+          title: 'Title',
+          text: 'Text',
+          type: 'success',
+        };
+
+        expect(wrapper.find(CssGroup).length).to.eq(0);
+        expect(wrapper.find(VelocityGroup).length).to.eq(1);
+      });
+    });
+  });
+
+  describe('with velocity animation library', () => {
+    const velocity = sinon.stub();
+    Notifications.configure({ velocity });
+
+    it('applies no additional inline styling to notification', (done) => {
+      const propsData = {
+        animationType: 'velocity',
+      };
+
+      const wrapper = mount(Notifications, { propsData });
+
+      const event = {
+        title: 'Title',
+        text: 'Text',
+        type: 'success',
+      };
+
+      wrapper.vm.addItem(event);
+
+      wrapper.vm.$nextTick(() => {
+        const notification = wrapper.first('.notification-wrapper');
+
+        expect(notification).to.exist;
+        expect(notification.element.style.transition).to.eq('');
+
+        done();
+      });
+    });
+
+    it('adds item to list', () => {
+      const propsData = {
+        animationType: 'velocity',
+      };
+
+      const wrapper = mount(Notifications, { propsData });
+
+      const event = {
+        title: 'Title',
+        text: 'Text',
+        type: 'success',
+      };
+
+      const result = wrapper.vm.addItem(event);
+
+      expect(wrapper.data().list.length).to.eq(1);
+      expect(wrapper.data().list[0].id).to.exist;
+      expect(wrapper.data().list[0].title).to.eq('Title');
+      expect(wrapper.data().list[0].text).to.eq('Text');
+      expect(wrapper.data().list[0].type).to.eq('success');
+      expect(wrapper.data().list[0].state).to.eq(0);
+      expect(wrapper.data().list[0].speed).to.eq(300);
+      expect(wrapper.data().list[0].length).to.eq(3600);
+      expect(wrapper.data().list[0].timer).to.exist;
+    });
+
+    it('calls velocity service for animations', () => {
+      const duration = 50;
+      const speed = 25;
+      const expectedLength = duration + 2 * speed;
+
+      const propsData = {
+        animationType: 'velocity',
+        duration,
+        speed,
+      };
+
+      const wrapper = mount(Notifications, { propsData });
+
+      const event = {
+        group: 'Group',
+        title: 'Title',
+        text: 'Text',
+        type: 'success',
+      };
+
+      const result = wrapper.vm.addItem(event);
+
+      expect(velocity.called).to.eq(true);
+    });
+  });
+});

--- a/test/unit/specs/util.spec.js
+++ b/test/unit/specs/util.spec.js
@@ -1,0 +1,107 @@
+import { Id, split, listToDirection } from '../../../src/util';
+
+describe('util functions', () => {
+  describe('Id', () => {
+    it('sequentially generates id starting with 0', () => {
+      const results = [...Array(5)].map(() => Id());
+
+      expect(results).to.deep.eq([0,1,2,3,4]);
+    });
+  });
+
+  describe('split', () => {
+    it('splits space-separated string into array', () => {
+      const value = 'taco pizza sushi'
+      const result = split(value);
+
+      expect(result).to.deep.eq(['taco', 'pizza', 'sushi']);
+    });
+
+    it('splits tab-separated string into array', () => {
+      const value = 'taco\tpizza\tsushi'
+      const result = split(value);
+
+      expect(result).to.deep.eq(['taco', 'pizza', 'sushi']);
+    });
+
+    it('removes empty string items', () => {
+      const value = 'taco \n \n \n'
+      const result = split(value);
+
+      expect(result).to.deep.eq(['taco']);
+    });
+
+    it('returns empty array when not a string value', () => {
+      const values = [
+        123,
+        undefined,
+        null,
+        {},
+        [],
+      ]
+
+      values.forEach((value) => {
+        const result = split(value);
+
+        expect(result).to.deep.eq([]);
+      });
+    });
+  });
+
+  describe('listToDirection', () => {
+    describe('when value is array', () => {
+      it('returns object with x and y keys representing position', () => {
+        const scenarios = [
+          { value: ['top', 'left'], result: { x: 'left', y: 'top'}},
+          { value: ['top', 'center'], result: { x: 'center', y: 'top'}},
+          { value: ['top', 'right'], result: { x: 'right', y: 'top'}},
+          { value: ['bottom', 'left'], result: { x: 'left', y: 'bottom'}},
+          { value: ['bottom', 'center'], result: { x: 'center', y: 'bottom'}},
+          { value: ['bottom', 'right'], result: { x: 'right', y: 'bottom'}},
+        ];
+
+        scenarios.forEach((scenario) => {
+          const result = listToDirection(scenario.value);
+
+          expect(result).to.deep.eq(scenario.result);
+        });
+      });
+    });
+
+    describe('when value is string', () => {
+      it('returns object with x and y keys representing position', () => {
+        const scenarios = [
+          { value: 'top left', result: { x: 'left', y: 'top'}},
+          { value: 'top center', result: { x: 'center', y: 'top'}},
+          { value: 'top right', result: { x: 'right', y: 'top'}},
+          { value: 'bottom left', result: { x: 'left', y: 'bottom'}},
+          { value: 'bottom center', result: { x: 'center', y: 'bottom'}},
+          { value: 'bottom right', result: { x: 'right', y: 'bottom'}},
+        ];
+
+        scenarios.forEach((scenario) => {
+          const result = listToDirection(scenario.value);
+
+          expect(result).to.deep.eq(scenario.result);
+        });
+      });
+    });
+
+    describe('when position is invalid', () => {
+      // TODO: may need to handle invalid cases better
+      it('returns null for the respective x or y key', () => {
+        const scenarios = [
+          { value: 'top pizza', result: { x: null, y: 'top' }},
+          { value: 'pizza right', result: { x: 'right', y: null }},
+          { value: 'taco pizza', result: { x: null, y: null }},
+        ];
+
+        scenarios.forEach((scenario) => {
+          const result = listToDirection(scenario.value);
+
+          expect(result).to.deep.eq(scenario.result);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Refs #23

* Add some basic coverage for`Notifications.vue` and `util.js`
* Uses `avoriaz` lib for vue test helpers
* Added Notifications.configure() to setup velocity
  * Had a circular dep issue when running tests
  * API should remain same as far as registering the Vue component
* Adds how to run tests in the README

## Validation

- [x] `npm install`
- [x] `npm run unit` to run tests. there's also a watch option.