### PR TITLE
Fix Issue #61 - fix error max parameter with bottom position

### DIFF
--- a/src/Notifications.vue
+++ b/src/Notifications.vue
@@ -242,7 +242,7 @@ const Component = {
         this.list.push(item)
 
         if (this.active.length > this.max) {
-          indexToDestroy = -1
+          indexToDestroy = 0
         }
       } else {
         this.list.unshift(item)


### PR DESCRIPTION
"Max" property doesn't work without reverse #61

I've just change the value of "indexToDestroy" when "direction" is true. 
I've tried every other case and for me nothing is broken