### PR TITLE
Add `clean` to typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,7 @@ export interface NotificationOptions {
     duration?: number;
     speed?: number;
     data?: object;
+    clean?: boolean;
 }
 
 declare module 'vue/types/vue' {


### PR DESCRIPTION
hey, this is fixing the issue I had here: https://github.com/euvl/vue-notification/issues/80

I wasn't sure if I should add all the other ones that are missing from here: https://www.npmjs.com/package/vue-notification#props

