### PR TITLE
Update scope to slot-scope in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Example:
 ```vue
 <notifications group="custom-template"  
                position="bottom right">
-   <template slot="body" scope="props">
+   <template slot="body" slot-scope="props">
     <div>
         <a class="title">
           {{props.item.title}}


### PR DESCRIPTION
Since Vue 2.5 `scope` was renamed `slot-scope`. Using `scope` will generate a deprecation warning.
I have tested that the props title and close function still work.