### PR TITLE
chore: add missing types for Vue.notify(#103)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,9 @@ declare module 'vue/types/vue' {
     interface Vue {
         $notify: (options: NotificationOptions | string) => void;
     }
+    interface VueConstructor {
+        notify: (options: NotificationOptions | string) => void;
+    }
 }
 
 declare class VueNotification {


### PR DESCRIPTION
close #103 