### PR TITLE
Fix ignoring duplicates

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -417,6 +417,8 @@ var Component = {
 
       var speed = typeof event.speed === 'number' ? event.speed : this.speed;
 
+      var ignoreDuplicates = typeof event.ignoreDuplicates === 'boolean' ? event.ignoreDuplicates : this.ignoreDuplicates;
+
       var title = event.title,
           text = event.text,
           type = event.type,
@@ -447,7 +449,7 @@ var Component = {
       var isDuplicate = Boolean(this.active.find(function (item) {
         return item.title === event.title && item.text === event.text;
       }));
-      var canAdd = this.ignoreDuplicates ? !isDuplicate : true;
+      var canAdd = ignoreDuplicates ? !isDuplicate : true;
 
       if (!canAdd) return;
 
@@ -841,7 +843,7 @@ module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c
       class: _vm.notifyClass(item),
       on: {
         "click": function($event) {
-          _vm.destroyIfNecessary(item)
+          return _vm.destroyIfNecessary(item)
         }
       }
     }, [(item.title) ? _c('div', {
@@ -855,10 +857,10 @@ module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c
         "innerHTML": _vm._s(item.text)
       }
     })])], {
-      item: item,
-      close: function () { return _vm.destroy(item); }
+      "item": item,
+      "close": function () { return _vm.destroy(item); }
     })], 2)
-  }))], 1)
+  }), 0)], 1)
 },staticRenderFns: []}
 
 /***/ }),

--- a/dist/ssr.js
+++ b/dist/ssr.js
@@ -417,6 +417,8 @@ var Component = {
 
       var speed = typeof event.speed === 'number' ? event.speed : this.speed;
 
+      var ignoreDuplicates = typeof event.ignoreDuplicates === 'boolean' ? event.ignoreDuplicates : this.ignoreDuplicates;
+
       var title = event.title,
           text = event.text,
           type = event.type,
@@ -447,7 +449,7 @@ var Component = {
       var isDuplicate = Boolean(this.active.find(function (item) {
         return item.title === event.title && item.text === event.text;
       }));
-      var canAdd = this.ignoreDuplicates ? !isDuplicate : true;
+      var canAdd = ignoreDuplicates ? !isDuplicate : true;
 
       if (!canAdd) return;
 
@@ -841,7 +843,7 @@ module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c
       class: _vm.notifyClass(item),
       on: {
         "click": function($event) {
-          _vm.destroyIfNecessary(item)
+          return _vm.destroyIfNecessary(item)
         }
       }
     }, [(item.title) ? _c('div', {
@@ -855,10 +857,10 @@ module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c
         "innerHTML": _vm._s(item.text)
       }
     })])], {
-      item: item,
-      close: function () { return _vm.destroy(item); }
+      "item": item,
+      "close": function () { return _vm.destroy(item); }
     })], 2)
-  }))], 1)
+  }), 0)], 1)
 },staticRenderFns: []}
 
 /***/ }),

--- a/src/Notifications.vue
+++ b/src/Notifications.vue
@@ -227,6 +227,10 @@ const Component = {
         ? event.speed
         : this.speed
 
+      const ignoreDuplicates = typeof event.ignoreDuplicates === 'boolean'
+        ? event.ignoreDuplicates
+        : this.ignoreDuplicates
+
       let { title, text, type, data } = event
 
       const item = {
@@ -253,7 +257,7 @@ const Component = {
       let indexToDestroy = -1
 
       const isDuplicate = Boolean(this.active.find(item => item.title === event.title && item.text === event.text));
-      const canAdd = this.ignoreDuplicates ? !isDuplicate : true;
+      const canAdd = ignoreDuplicates ? !isDuplicate : true;
 
       if (!canAdd) return;
 


### PR DESCRIPTION
Relates to #132.

Changes include:
- Use `ignoreDuplicates` component prop as a fallback option instead of always relying on it.
- Use `ignoreDuplicates` flag coming from config param in `Vue.notify` function.