### PR TITLE
Issue 169, 145 & 175 Q2 resolved with this PR, a new event @onClick i…

### DIFF
--- a/src/Notifications.vue
+++ b/src/Notifications.vue
@@ -218,7 +218,7 @@ const Component = {
   },
   methods: {
     destroyIfNecessary (item) {
-      this.$emit('onClick', item)
+      this.$emit('click', item)
       if (this.closeOnClick) {
         this.destroy(item)
       }

--- a/src/Notifications.vue
+++ b/src/Notifications.vue
@@ -153,6 +153,11 @@ const Component = {
     pauseOnHover: {
       type: Boolean,
       default: false
+    },
+
+    onDestroy: {
+      type: Function,
+      default: () => {}
     }
 
   },
@@ -213,6 +218,7 @@ const Component = {
   },
   methods: {
     destroyIfNecessary (item) {
+      this.$emit('onClick', item)
       if (this.closeOnClick) {
         this.destroy(item)
       }
@@ -325,6 +331,10 @@ const Component = {
 
       if (!this.isVA) {
         this.clean()
+      }
+
+      if(typeof this.onDestroy === 'function') {
+        this.onDestroy(item);
       }
     },
 

--- a/src/Notifications.vue
+++ b/src/Notifications.vue
@@ -153,11 +153,6 @@ const Component = {
     pauseOnHover: {
       type: Boolean,
       default: false
-    },
-
-    onDestroy: {
-      type: Function,
-      default: () => {}
     }
 
   },
@@ -333,9 +328,7 @@ const Component = {
         this.clean()
       }
 
-      if(typeof this.onDestroy === 'function') {
-        this.onDestroy(item);
-      }
+      this.$emit('destroy', item)
     },
 
     destroyById (id) {


### PR DESCRIPTION
## Changes in PR:

Issue #169 , #145  & #175  Q2 resolved with this PR, 

1. A new event `@onClick` is introduced, which gets emitted whenever user clicks on the notification, this emit method also returns the item data of the respective notification instance.
2. A new `onDestroy ` callback method is introduced as a prop, 
    a. it'll get invoked either when user clicks on the notification and if onCloseClick was set to true.
    b. It'll get invoked when notification auto-destroys.

Thus developers can pass a callback function and catch onDestroy hook with respective notification item data.

![image](https://user-images.githubusercontent.com/14342057/83445167-22780100-a46a-11ea-8fac-25684070d03a.png)




