### PR TITLE
Ensure `item.data` is always present

### DIFF
--- a/src/Notifications.vue
+++ b/src/Notifications.vue
@@ -230,6 +230,7 @@ const Component = {
     },
     addItem (event) {
       event.group = event.group || ''
+      event.data = event.data || {}
 
       if (this.group !== event.group) {
         return


### PR DESCRIPTION
## Changes in PR:

- Ensure `item.data` is always available in the template

## Issue

- https://github.com/euvl/vue-notification/issues/210