### PR TITLE
Improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,23 +7,22 @@
 [![npm version](https://badge.fury.io/js/vue-notification.svg)](https://badge.fury.io/js/vue-notification)
 [![npm](https://img.shields.io/npm/dm/vue-notification.svg)](https://www.npmjs.com/package/vue-notification)
 
-### Vue.js notifications
+# Vue.js notifications
 
 Demo: http://vue-notification.yev.io/
 
 <p align="center">
   <img src="https://media.giphy.com/media/xUn3C6FmbGmszMem64/giphy.gif">
 </p>
+## Setup
 
-### Install
+Install via the command line:
 
 ```bash
 npm install --save vue-notification
 ```
 
-### How to
-
-In main.js:
+Add dependencies to your `main.js`:
 
 ```javascript
 import Vue           from 'vue'
@@ -37,53 +36,51 @@ import Notifications from 'vue-notification/dist/ssr.js'
 Vue.use(Notifications)
 ```
 
-In App.vue:
+Add the global component to your `App.vue`:
 
 ```vue
-<notifications group="foo" />
+<notifications/>
 ```
 
-In any of your vue files:
+Trigger notifications from your `.vue` files:
 
 ```javascript
+// simple
+this.$notify('Hello user!')
+
+// using options
 this.$notify({
-  group: 'foo',
   title: 'Important message',
-  text: 'Hello user! This is a notification!'
+  text: 'Hello user!'
 });
 ```
 
-Anywhere else:
+Or trigger notifications from other files, for example, your router:
 
 ```javascript
 import Vue from 'vue'
 
 Vue.notify({
-  group: 'foo',
-  title: 'Important message',
-  text: 'Hello user! This is a notification!'
+  title: 'Authorization',
+  text: 'You have been logged in!'
 })
 ```
 
-### Custom instance configuration
+## Usage
 
-All configurations are optional.
+### Component props
 
-| Name           | Type    | Default       | Description |
-| ---            | ---     | ---           | ---         |
-| name           | String  | notify        | Defines the instance name. It's prefixed with the dollar sign. E.g. `$notify` |
-| componentName  | String  | notifications | The component's name |
+You configure the majority of settings for the Notifications component using props:
 
-P.S. Setting `componentName` can cause issues when using SSR.
+```vue
+<notifications position="bottom right" classes="my-custom-class"/>
+```
 
-### Props
-
-All props are optional.
+Note that all props are optional.
 
 | Name             | Type    | Default      | Description |
 | ---              | ---     | ---          | ---         |
 | group            | String  | null         | Name of the notification holder, if specified |
-| type             | String  | null         | Class that will be assigned to the notification (**warn**, **error**, **success**, etc) |
 | width            | Number/String  | 300          | Width of notification holder, can be `%`, `px` string or number.<br>Valid values: '100%', '200px', 200 |
 | classes          | String/Array | 'vue-notification' | List of classes that will be applied to notification element |
 | position         | String/Array | 'top right'  | Part of the screen where notifications will pop out |
@@ -99,7 +96,9 @@ All props are optional.
 
 $ = `{enter: {opacity: [1, 0]}, leave: {opacity: [0, 1]}}`
 
-### API
+### JavaScript API
+
+You trigger notifications via the API:
 
 ```javascript
   this.$notify({
@@ -113,17 +112,17 @@ $ = `{enter: {opacity: [1, 0]}, leave: {opacity: [0, 1]}}`
 
     // (optional)
     // Title (will be wrapped in div.notification-title)
-    title: 'This is title',
+    title: 'This is the <em>title</em>',
 
     // Content (will be wrapped in div.notification-content)
-    text: 'This is <b> content </b>',
+    text: 'This is some <b>content</b>',
 
     // (optional)
-    // Overrides default/provided duration
+    // Delay in milliseconds (overrides default/provided duration)
     duration: 10000,
 
     // (optional)
-    // Overrides default/provided animation speed
+    // Speed in milliseconds (overrides default/provided animation speed)
     speed: 1000
 
     // (optional)
@@ -132,55 +131,110 @@ $ = `{enter: {opacity: [1, 0]}, leave: {opacity: [0, 1]}}`
   })
 ```
 
-Title and Text can be HTML strings.
-
-Also you can use simplified version:
+To remove notifications, include the `clean: true` parameter.
 
 ```javascript
-this.$notify('text')
+this.$notify({
+  group: 'foo', // clean only the foo group
+  clean: true
+})
 ```
 
-### Groups
+### Plugin Options
 
-If you are planning to use `notification` component for 2 or more completely different types of notifications (for example, authentication error messages in top center and generic app notifications in bottom-right corner) - you can specify `group` property which is essentially a name of notification holder.
+You can configure the plugin itself with an additional options object:
 
-Example:
-
-```vue
-<notifications group="auth"/>
-<notifications group="app"/>
+```js
+Vue.use(notifications, { name: 'alert' })
 ```
 
-```javascript
-this.$notify({ group: 'auth', text: 'Wrong password, please try again later' })
-```
+All options are optional:
+
+| Name          | Type   | Default       | Description                                                  |
+| ------------- | ------ | ------------- | ------------------------------------------------------------ |
+| name          | String | notify        | Defines the instance name. It's prefixed with the dollar sign. E.g. `$notify` |
+| componentName | String | notifications | The component's name                                         |
+
+>  **Note**: setting `componentName` can cause issues when using SSR.
+
+## Features
 
 ### Position
 
-`Position` property requires a string with 2 keywords for vertical and horizontal postion.
+You can position the component on the screen, using the `position` prop:
+
+```vue
+<notifications position="bottom right"/>
+```
+
+It requires a `string` with **two keywords** for vertical and horizontal postion.
 
 Format: `"<vertical> <horizontal>"`.
 
 - Horizontal options: `left`, `center`, `right`
 - Vertical options: `top`, `bottom`
 
-Default is "top right".
+Default is `"top right"`.
 
-Example:
+### Width
+
+Width can be set using a `number` or `string` with optional `%` or `px` extensions:
 
 ```vue
-<notifications position="top left"/>
+<notifications :width="100"/>
+<notifications width="100"/>
+<notifications width="100%"/>
+<notifications width="100px"/>
 ```
 
-### Style
+### Type
 
-You can write your own css styles for notifications:
+You can set the `type` of a notification (**warn**, **error**, **success**, etc) by adding a `type` property to the call:
 
-Structure:
+```js
+this.$notify({ type: 'success', text: 'The operation completed' })
+```
+
+This will add the `type` (i.e. "success") as a CSS class name to the `.vue-notification` element.
+
+See the [Styling](#styling) section for how to hook onto the class and style the popup.
+
+### Groups
+
+If you require different classes of notifications, i.e...
+
+- authentication errors (top center)
+- app notifications (bottom-right)
+
+...you can specify the `group` attribute:
+
+```vue
+<notifications group="auth" position="top"/>
+<notifications group="app"  position="bottom right"/>
+```
+
+You can trigger a notification for a specific group by specifying it in the API call:
+
+```javascript
+this.$notify({ group: 'auth', text: 'Wrong password, please try again' })
+```
+
+## Customisation
+
+### Styling
+
+Vue Notifications comes with default styling, but it's easy to assign your own.
+
+First, assign a the `classes` property to the component:
+
+```vue
+<notifications classes="my-style"/>
+```
+
+Then simply write your own css styles for notifications:
 
 ```scss
-// SCSS:
-
+// scss
 .my-style {
   // Style of the notification itself
 
@@ -202,24 +256,26 @@ Structure:
 }
 ```
 
-To apply this style you will have to specify "classes" property:
-
-```vue
-  <notifications classes="my-style"/>
-```
-
-**Default:**
+Note that the default styling looks like this:
 
 ```scss
+// scss
 .vue-notification {
-  padding: 10px;
+  // styling
   margin: 0 5px 5px;
-
+  padding: 10px;
   font-size: 12px;
-
   color: #ffffff;
+  
+  // default (blue)
   background: #44A4FC;
   border-left: 5px solid #187FE7;
+
+  // types (green, amber, red)
+  &.success {
+    background: #68CD86;
+    border-left-color: #42A85F;
+  }
 
   &.warn {
     background: #ffb648;
@@ -230,56 +286,42 @@ To apply this style you will have to specify "classes" property:
     background: #E54D42;
     border-left-color: #B82E24;
   }
-
-  &.success {
-    background: #68CD86;
-    border-left-color: #42A85F;
-  }
 }
 ```
 
-### Custom template (slot)
+### Content
 
-Optional scope slot named "body" is supported.
-
-Scope props:
-
-| Name  | Type     | Description                         |
-| ---   | ---      | ---                                 |
-| item  | Object   | notification object                 |
-| close | Function | when called closes the notification |
-
-Example:
+You can completely replace the content of the notifications by using Vue's slots system.
 
 ```vue
-<notifications group="custom-template"  
-               position="bottom right">
-   <template slot="body" slot-scope="props">
+<notifications position="bottom right">
+  <template slot="body" slot-scope="{ item, close }">
     <div>
-        <a class="title">
-          {{props.item.title}}
-        </a>
-        <a class="close" @click="props.close">
-          <i class="fa fa-fw fa-close"></i>
-        </a>
-        <div v-html="props.item.text">
-        </div>
+      <p class="title">
+        {{ item.title }}
+      </p>
+      <a class="close" @click="close">
+        <i class="fa fa-fw fa-close"></i>
+      </a>
+      <div v-html="props.item.text"/>
     </div>
   </template>
 </notifications>
 ```
+The `props` object has the following members:
+
+| Name  | Type     | Description                          |
+| ----- | -------- | ------------------------------------ |
+| item  | Object   | Notification object                  |
+| close | Function | A function to close the notification |
+
 <a name="velocity_animation"></a>
 
+### Animation
 
-### Width
+Vue Notification can use use [Velocity](https://github.com/julianshapiro/velocity) library to make js-powered animations.
 
-Width can be set using a string with a percent or pixel extension (if simple number is not enough).
-
-Examples: '100%', '50px', '50', 50
-
-### Velocity Animation
-
-Plugin can use use `Velocity` library to make js-powered animations. To start using it you will have to manually install `velocity-animate` & supply the librarty to `vue-notification` plugin (reason for doing that is to reduce the size of this plugin).
+To start using it you will have to manually install `velocity-animate` & supply the librarty to `vue-notification` plugin (reason for doing that is to reduce the size of this plugin).
 
 In your `main.js`:
 
@@ -297,9 +339,7 @@ In the template you will have to set `animation-type="velocity"`.
 <notifications animation-type="velocity"/>
 ```
 
-The animation configuration consists of 2 objects/functions: `enter` and `leave`.
-
-Example:
+The animation configuration consists of 2 objects/functions: `enter` and `leave`:
 
 ```javascript
 /*
@@ -328,28 +368,17 @@ animation = {
 }
 ```
 
+The assign the animation along with the engine in the template:
+
 ```vue
-<notifications
-  animation-type="velocity"
-  animation="animation"/>
+<notifications animation-type="velocity" animation="animation"/>
 ```
 
-### Cleaning
-
-To remove all notifications, use `clean: true` parameter.
-
-```javascript
-this.$notify({
-  group: 'foo',
-  clean: true
-})
-```
-
-### FAQ
+## FAQ
 
 Check closed issues with `FAQ` label to get answers for most asked questions.
 
-### Development
+## Development
 
 ```bash
 To run an example:
@@ -372,3 +401,5 @@ npm run test
 # Watch unit tests
 npm run unit:watch
 ```
+
+

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
 
 ## Demo
 
-View a live demo here:
 
 - http://vue-notification.yev.io/
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Vue.notify({
 
 ### Component props
 
-You configure the majority of settings for the Notifications component using props:
+The majority of settings for the Notifications component are configured using props:
 
 ```vue
 <notifications position="bottom right" classes="my-custom-class"/>
@@ -99,7 +99,7 @@ Note that all props are optional.
 
 ### API
 
-You trigger notifications via the API:
+Notifications are triggered via the API:
 
 ```javascript
   this.$notify({
@@ -143,7 +143,7 @@ this.$notify({
 
 ### Plugin Options
 
-You can configure the plugin itself with an additional options object:
+Configure the plugin itself using an additional options object:
 
 ```js
 Vue.use(notifications, { name: 'alert' })
@@ -162,7 +162,7 @@ All options are optional:
 
 ### Position
 
-You can position the component on the screen, using the `position` prop:
+Position the component on the screen using the `position` prop:
 
 ```vue
 <notifications position="bottom right"/>
@@ -190,7 +190,7 @@ Width can be set using a `number` or `string` with optional `%` or `px` extensio
 
 ### Type
 
-You can set the `type` of a notification (**warn**, **error**, **success**, etc) by adding a `type` property to the call:
+Set the `type` of a notification (**warn**, **error**, **success**, etc) by adding a `type` property to the call:
 
 ```js
 this.$notify({ type: 'success', text: 'The operation completed' })
@@ -202,19 +202,19 @@ See the [Styling](#styling) section for how to hook onto the class and style the
 
 ### Groups
 
-If you require different classes of notifications, i.e...
+For different classes of notifications, i.e...
 
 - authentication errors (top center)
 - app notifications (bottom-right)
 
-...you can specify the `group` attribute:
+...specify the `group` attribute:
 
 ```vue
 <notifications group="auth" position="top"/>
 <notifications group="app"  position="bottom right"/>
 ```
 
-You can trigger a notification for a specific group by specifying it in the API call:
+Trigger a notification for a specific group by specifying it in the API call:
 
 ```javascript
 this.$notify({ group: 'auth', text: 'Wrong password, please try again' })
@@ -226,7 +226,7 @@ this.$notify({ group: 'auth', text: 'Wrong password, please try again' })
 
 Vue Notifications comes with default styling, but it's easy to replace with your own.
 
-Use the `classes` prop on the global component:
+Specify one or more class hooks via the `classes` prop on the global component:
 
 ```vue
 <notifications classes="my-notification"/>
@@ -243,7 +243,7 @@ This will add the supplied class/classes to individual notification elements:
 </div>
 ```
 
-Then simply write your own css rules to style the notifications:
+Then include custom css rules to style the notifications:
 
 ```scss
 // style of the notification itself
@@ -301,7 +301,7 @@ Note that the default rules are:
 
 ### Content
 
-You can completely replace the content of the notifications by using Vue's slots system.
+To completely replace notification content, use Vue's slots system:
 
 ```vue
 <notifications>
@@ -331,7 +331,7 @@ The `props` object has the following members:
 
 Vue Notification can use the [Velocity](https://github.com/julianshapiro/velocity) library to power the animations using JavaScript.
 
-To start using it you will have to manually install `velocity-animate` & pass the library to the  `vue-notification` plugin (the reason for doing that is to reduce the size of this plugin).
+To use, manually install `velocity-animate` & pass the library to the  `vue-notification` plugin (the reason for doing that is to reduce the size of this plugin).
 
 In your `main.js`:
 
@@ -343,13 +343,13 @@ import velocity      from 'velocity-animate'
 Vue.use(Notifications, { velocity })
 ```
 
-In the template you will have to set `animation-type="velocity"`.
+In the template, set the `animation-type` prop:
 
 ```vue
 <notifications animation-type="velocity"/>
 ```
 
-The animation configuration consists of 2 objects/functions: `enter` and `leave`, which defaults to:
+The default configuration is:
 
 ```js
 {
@@ -358,7 +358,13 @@ The animation configuration consists of 2 objects/functions: `enter` and `leave`
 }
 ```
 
-You can also provide your own configuration, for example:
+To assign a custom animation, use the `animation` prop:
+
+```vue
+<notifications animation-type="velocity" :animation="animation"/>
+```
+
+Note that `enter` and `leave` can be an `object` or a `function` that returns an `object`:
 
 ```javascript
 computed: {
@@ -387,12 +393,6 @@ computed: {
     }
   }
 }
-```
-
-Assign your custom configuration as a component prop:
-
-```vue
-<notifications animation-type="velocity" :animation="animation"/>
 ```
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Demo: http://vue-notification.yev.io/
 <p align="center">
   <img src="https://media.giphy.com/media/xUn3C6FmbGmszMem64/giphy.gif">
 </p>
+
 ## Setup
 
 Install via the command line:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 <p align="center">
   <img src="https://media.giphy.com/media/xUn3C6FmbGmszMem64/giphy.gif">
 </p>
+
 ## Demo
 
 View a live demo here:

--- a/README.md
+++ b/README.md
@@ -9,11 +9,14 @@
 
 # Vue.js notifications
 
-Demo: http://vue-notification.yev.io/
-
 <p align="center">
   <img src="https://media.giphy.com/media/xUn3C6FmbGmszMem64/giphy.gif">
 </p>
+## Demo
+
+View a live demo here:
+
+- http://vue-notification.yev.io/
 
 ## Setup
 
@@ -79,23 +82,21 @@ You configure the majority of settings for the Notifications component using pro
 
 Note that all props are optional.
 
-| Name             | Type    | Default      | Description |
-| ---              | ---     | ---          | ---         |
-| group            | String  | null         | Name of the notification holder, if specified |
-| width            | Number/String  | 300          | Width of notification holder, can be `%`, `px` string or number.<br>Valid values: '100%', '200px', 200 |
-| classes          | String/Array | 'vue-notification' | List of classes that will be applied to notification element |
-| position         | String/Array | 'top right'  | Part of the screen where notifications will pop out |
-| animation-type   | String  | 'css'      | Type of animation, currently supported types are `css` and `velocity` |
-| animation-name   | String  | null       | Animation name required for `css` animation |
-| animation        | Object  | `$`*         | Animation configuration for `Velocity` animation |
-| duration         | Number  | 3000         | Time (ms) animation stays visible (if **negative** - notification will stay **forever** or until clicked) |
-| speed            | Number  | 300          | Speed of animation showing/hiding |
-| max              | Number  | Infinity     | Maximum number of notifications that can be shown in notification holder |
-| reverse          | Boolean | false        | Show notifications in reverse order |
-| ignoreDuplicates | Boolean | false        | Ignore repeated instances of the same notification |
-| closeOnClick     | Boolean | true         | Close notification when clicked |
-
-$ = `{enter: {opacity: [1, 0]}, leave: {opacity: [0, 1]}}`
+| Name             | Type          | Default            | Description                                                  |
+| ---------------- | ------------- | ------------------ | ------------------------------------------------------------ |
+| position         | String/Array  | 'top right'        | Part of the screen where notifications will pop out          |
+| width            | Number/String | 300                | Width of notification holder, can be `%`, `px` string or number.<br>Valid values: '100%', '200px', 200 |
+| classes          | String/Array  | 'vue-notification' | List of classes that will be applied to notification element |
+| group            | String        | null               | Name of the notification holder, if specified                |
+| duration         | Number        | 3000               | Time (in ms) to keep the notification on screen (if **negative** - notification will stay **forever** or until clicked) |
+| speed            | Number        | 300                | Time (in ms) to show / hide notifications                    |
+| animation-type   | String        | 'css'              | Type of animation, currently supported types are `css` and `velocity` |
+| animation-name   | String        | null               | Animation name required for `css` animation                  |
+| animation        | Object        | Custom             | Animation configuration for [Velocity](#Animation]) animation |
+| max              | Number        | Infinity           | Maximum number of notifications that can be shown in notification holder |
+| reverse          | Boolean       | false              | Show notifications in reverse order                          |
+| ignoreDuplicates | Boolean       | false              | Ignore repeated instances of the same notification           |
+| closeOnClick     | Boolean       | true               | Close notification when clicked                              |
 
 ### JavaScript API
 
@@ -108,10 +109,6 @@ You trigger notifications via the API:
     group: 'foo',
 
     // (optional)
-    // Class that will be assigned to the notification
-    type: 'warn',
-
-    // (optional)
     // Title (will be wrapped in div.notification-title)
     title: 'This is the <em>title</em>',
 
@@ -119,11 +116,15 @@ You trigger notifications via the API:
     text: 'This is some <b>content</b>',
 
     // (optional)
-    // Delay in milliseconds (overrides default/provided duration)
+    // Class that will be assigned to the notification
+    type: 'warn',
+
+    // (optional, override)
+    // Time (in ms) to keep the notification on screen
     duration: 10000,
 
-    // (optional)
-    // Speed in milliseconds (overrides default/provided animation speed)
+    // (optional, override)
+    // Time (in ms) to show / hide notifications
     speed: 1000
 
     // (optional)
@@ -320,9 +321,9 @@ The `props` object has the following members:
 
 ### Animation
 
-Vue Notification can use use [Velocity](https://github.com/julianshapiro/velocity) library to make js-powered animations.
+Vue Notification can use the [Velocity](https://github.com/julianshapiro/velocity) library to power the animations using JavaScript.
 
-To start using it you will have to manually install `velocity-animate` & supply the librarty to `vue-notification` plugin (reason for doing that is to reduce the size of this plugin).
+To start using it you will have to manually install `velocity-animate` & pass the library to the  `vue-notification` plugin (the reason for doing that is to reduce the size of this plugin).
 
 In your `main.js`:
 
@@ -340,39 +341,50 @@ In the template you will have to set `animation-type="velocity"`.
 <notifications animation-type="velocity"/>
 ```
 
-The animation configuration consists of 2 objects/functions: `enter` and `leave`:
+The animation configuration consists of 2 objects/functions: `enter` and `leave`, which defaults to:
+
+```js
+{
+  enter: { opacity: [1, 0] },
+  leave: { opacity: [0, 1] }
+}
+```
+
+You can also supply your own configuration, for example:
 
 ```javascript
-/*
- * Both 'enter' and 'leave' can be either an object or a function
- */
-animation = {
-  enter (element) {
-     /*
-      *  "element" - is a notification element
-      *    (before animation, meaning that you can take it's initial height, width, color, etc)
-      */
-     let height = element.clientHeight
+computed: {
+  animation () {
+    return {
+      /**
+       * Animation function
+       * 
+       * Runs before animating, so you can take the initial height, width, color, etc
+       * @param  {HTMLElement}  element  The notification element
+       */
+      enter (element) {
+        let height = element.clientHeight
+        return {
+          // animates from 0px to "height"
+          height: [height, 0],
 
-     return {
-       // Animates from 0px to "height"
-       height: [height, 0],
-
-       // Animates from 0 to random opacity (in range between 0.5 and 1)
-       opacity: [Math.random() * 0.5 + 0.5, 0]
-     }  
-  },
-  leave: {
-    height: 0,
-    opacity: 0
+          // animates from 0 to random opacity (in range between 0.5 and 1)
+          opacity: [Math.random() * 0.5 + 0.5, 0]
+        }
+      },
+      leave: {
+        height: 0,
+        opacity: 0
+      }
+    }
   }
 }
 ```
 
-The assign the animation along with the engine in the template:
+Assign your custom configuration as a component prop:
 
 ```vue
-<notifications animation-type="velocity" animation="animation"/>
+<notifications animation-type="velocity" :animation="animation"/>
 ```
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Note that all props are optional.
 | ignoreDuplicates | Boolean       | false              | Ignore repeated instances of the same notification           |
 | closeOnClick     | Boolean       | true               | Close notification when clicked                              |
 
-### JavaScript API
+### API
 
 You trigger notifications via the API:
 
@@ -424,5 +424,4 @@ npm run test
 # Watch unit tests
 npm run unit:watch
 ```
-
 

--- a/README.md
+++ b/README.md
@@ -226,43 +226,52 @@ this.$notify({ group: 'auth', text: 'Wrong password, please try again' })
 
 ### Styling
 
-Vue Notifications comes with default styling, but it's easy to assign your own.
+Vue Notifications comes with default styling, but it's easy to replace with your own.
 
-First, assign a the `classes` property to the component:
+Use the `classes` prop on the global component:
 
 ```vue
-<notifications classes="my-style"/>
+<notifications classes="my-notification"/>
 ```
 
-Then simply write your own css styles for notifications:
+This will add the supplied class/classes to individual notification elements:
+
+```html
+<div class="vue-notification-wrapper">
+  <div class="vue-notification-template my-notification">
+    <div class="notification-title">Info</div>
+    <div class="notification-content">You have been logged in</div>
+  </div>
+</div>
+```
+
+Then simply write your own css rules to style the notifications:
 
 ```scss
-// scss
-.my-style {
-  // Style of the notification itself
+// style of the notification itself
+.my-notification {
+  ...
 
+  // style for title line
   .notification-title {
-    // Style for title line
+    ...
   }
 
+  // style for content
   .notification-content {
-    // Style for content
+    ...
   }
 
-  &.my-type {
-    /*
-    Style for specific type of notification, will be applied when you
-    call notification with "type" parameter:
-    this.$notify({ type: 'my-type', message: 'Foo' })
-    */
-  }
+  // additional styling hook when using`type` parameter, i.e. this.$notify({ type: 'success', message: 'Yay!' })
+  &.success { ... }
+  &.info { ... }
+  &.error { ... }
 }
 ```
 
-Note that the default styling looks like this:
+Note that the default rules are:
 
 ```scss
-// scss
 .vue-notification {
   // styling
   margin: 0 5px 5px;
@@ -297,15 +306,15 @@ Note that the default styling looks like this:
 You can completely replace the content of the notifications by using Vue's slots system.
 
 ```vue
-<notifications position="bottom right">
+<notifications>
   <template slot="body" slot-scope="{ item, close }">
-    <div>
+    <div class="my-notification">
       <p class="title">
         {{ item.title }}
       </p>
-      <a class="close" @click="close">
+      <button class="close" @click="close">
         <i class="fa fa-fw fa-close"></i>
-      </a>
+      </button>
       <div v-html="props.item.text"/>
     </div>
   </template>

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ The animation configuration consists of 2 objects/functions: `enter` and `leave`
 }
 ```
 
-You can also supply your own configuration, for example:
+You can also provide your own configuration, for example:
 
 ```javascript
 computed: {
@@ -424,4 +424,3 @@ npm run test
 # Watch unit tests
 npm run unit:watch
 ```
-

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@
 
 ## Setup
 
-Install via the command line:
 
 ```bash
 npm install --save vue-notification

--- a/README.md
+++ b/README.md
@@ -401,24 +401,25 @@ Check closed issues with `FAQ` label to get answers for most asked questions.
 
 ## Development
 
+To run a local demo:
+
 ```bash
-To run an example:
-
-# Build main library
-
-cd vue-notification
-npm install
-npm run build
-
-# Build and run demo
-
+# run the demo
 cd demo
 npm install
 npm run dev
+```
 
-# Run tests
+To contribute to the library:
+
+```bash
+# build main library
+npm install
+npm run build
+
+# run tests
 npm run test
 
-# Watch unit tests
+# watch unit tests
 npm run unit:watch
 ```

--- a/src/Notifications.vue
+++ b/src/Notifications.vue
@@ -230,6 +230,7 @@ const Component = {
     },
     addItem (event) {
       event.group = event.group || ''
+      event.data = event.data || {}
 
       if (this.group !== event.group) {
         return


### PR DESCRIPTION
## Changes in PR:

Review and improve readme:

Discoverability:

- use H2 and H3 headings to make it easier to navigate
- place examples first, before options 

Organisation:

- added an initial Demo section
- create 4 main sections: Setup, Usage, Features, Customisation
- move plugin configuration to "Usage > Plugin" section, and provide example
- move misc props examples to "Usage > Props" section
- move styles examples to "Customisation > Styles" section 
- move template example to "Customisation > Content" section 
- move Velocity animation example to "Customisation > Animation" section, and provide example
- move `clean` example to "Usage > API" 

Improvements:

- make the "Setup" steps simpler and the language more descriptive
- show "simple" and "options" example at beginning
- remove `group` parameter from basic examples (makes it easier to run code as a first-timer)
- specifically document "type" under "Features"
- order the props in a way that makes mores sense to first time users
- put the simpler features before the more complex features (before, Groups was first)
- improve various examples, including "groups"
- destructured slot `props` in template example
- various other bits and bobs here and there!
 
Fixes:

 - remove invalid `type` from props list
 
 Closes #209 