### PR TITLE
Fix memory leak

### DIFF
--- a/src/Notifications.vue
+++ b/src/Notifications.vue
@@ -167,6 +167,10 @@ const Component = {
     events.$on('add', this.addItem);
     events.$on('close', this.closeItem);
   },
+  beforeDestroy() {
+    events.$off();
+    this.destroyAll();
+  },
   computed: {
     actualWidth () {
       return parseNumericValue(this.width)


### PR DESCRIPTION
## Changes in PR:

In the mounted hook, we add event listeners that we never remove. This PR removes them on beforeDestroy.

I was facing a memory leak in our Rails/Vue application, and using the memory tab in DevTools it was easy to see that the lib was the culprit (screenshot below); without this fix, the entire Vue app that relies on vue-notification will always be kept in memory even after unmounting; we even call $destroy on our app instances directly, because it's a Rails/Turbolinks app so we need to cleanup after ourselves, but even with that the lib will retain the entire app in memory.

In our app, after switching screens 10 times, without this fix, memory usage goes to 150MB. With this fix, it comes back down to 20mb.

![image](https://user-images.githubusercontent.com/743879/136023240-4ce4ac08-5892-4813-88e0-fc83a067b795.png)
