### PR TITLE
Added tag="div" to transition-group in CssGroup.vue

### DIFF
--- a/src/CssGroup.vue
+++ b/src/CssGroup.vue
@@ -1,5 +1,5 @@
 <template>
-  <transition-group :name="name">
+  <transition-group tag="div" :name="name">
     <slot/>
   </transition-group>
 </template>


### PR DESCRIPTION
`<transition-group>` in `CssGroup.vue` doesn't have specified `tag` prop, so `<span>` tag is used by default. Children of `CssGroup.vue` are block-level elements. Syntactically, a block-level element inside an inline element is invalid in all standards of HTML. This can cause various issues, for example, an issue with the hydration process in SSR applications.

## Changes in PR:
Added `tag` prop to `<transition-group>` in `CssGroup.vue` and set it to `"div"`
